### PR TITLE
fix: export ModelOptions FunctionModel ObjectModel

### DIFF
--- a/packages/doura/src/index.ts
+++ b/packages/doura/src/index.ts
@@ -6,7 +6,6 @@ export type {
   ModelPublicInstance,
   ModelManagerOptions,
   AnyObjectModel,
-  FunctionModel,
   AnyFunctionModel,
   AnyModel,
   State,
@@ -18,6 +17,9 @@ export type {
   ModelViews,
   ModelData,
   ModelAPI,
+  ModelOptions,
+  FunctionModel,
+  ObjectModel,
 } from './core'
 
 export { defineModel, nextTick } from './core'

--- a/packages/doura/src/index.ts
+++ b/packages/doura/src/index.ts
@@ -6,6 +6,7 @@ export type {
   ModelPublicInstance,
   ModelManagerOptions,
   AnyObjectModel,
+  FunctionModel,
   AnyFunctionModel,
   AnyModel,
   State,


### PR DESCRIPTION
```ts
export const countModel = defineModel({
  state: { count: 1 },
  actions: {
    add(p: number) {
      this.count += p
    },
  },
  views: {
    double() {
      return this.count * 2
    },
  },
})
```

Exported variable 'countModel' has or is using name 'FunctionModel' from external module "/Users/user/project/shuvi/node_modules/.pnpm/doura@0.0.2/node_modules/doura/dist/doura" but cannot be named.ts(4023)