### PR TITLE
chore: build types should be default setting

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -26,7 +26,7 @@ const devOnly = args.devOnly || args.d
 const prodOnly = !devOnly && (args.prodOnly || args.p)
 const sourceMap = args.sourcemap || args.s
 const isRelease = args.release
-const buildTypes = args.t || args.types || isRelease
+const buildTypes = true
 const buildAllMatching = args.all || args.a
 const commit = execa.sync('git', ['rev-parse', 'HEAD']).stdout.slice(0, 7)
 


### PR DESCRIPTION
Fixed demo typo error, both on the demo and the example packages with `pnpm build`
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/28706090/205957004-fcc2baa8-3fe0-4cbe-8ced-66d435a416bc.png">
