### PR TITLE
chore: update speed Doura x 2,246 ops/sec ±4.10%

### DIFF
--- a/packages/doura/src/utils.ts
+++ b/packages/doura/src/utils.ts
@@ -71,12 +71,9 @@ export function invariant(condition: any, message?: string): asserts condition {
 
 const slice = Array.prototype.slice
 
-export function shallowCopy(base: any) {
-  if (isMap(base)) return new Map(base)
-  if (isSet(base)) return new Set(base)
-  if (Array.isArray(base)) return slice.call(base)
+function strictCopy(base: any) {
   const descriptors = Object.getOwnPropertyDescriptors(base)
-  const keys = Reflect.ownKeys(descriptors)
+  const keys = ownKeys(descriptors)
   for (let i = 0; i < keys.length; i++) {
     const key: any = keys[i]
     const desc = descriptors[key]
@@ -96,6 +93,40 @@ export function shallowCopy(base: any) {
       }
   }
   return Object.create(Object.getPrototypeOf(base), descriptors)
+}
+
+const isEnumerable = Object.prototype.propertyIsEnumerable
+
+// For best performance with shallow copies,
+// don't use `Object.create(Object.getPrototypeOf(obj), Object.getOwnPropertyDescriptors(obj));` by default.
+function quickCopyObj(base: any) {
+  const copy: Record<string | symbol, any> = {}
+  const keys = ownKeys(base)
+  for (let i = 0; i < keys.length; i++) {
+    const key: any = keys[i]
+    const target = base[key]
+    if (isEnumerable.call(base, key)) {
+      copy![key] = target
+    } else {
+      Object.defineProperty(copy, key, {
+        configurable: true,
+        writable: true,
+        enumerable: false,
+        value: target,
+      })
+    }
+  }
+  return copy
+}
+
+export function shallowCopy(base: any) {
+  if (Array.isArray(base)) return slice.call(base)
+  if (isMap(base)) return new Map(base)
+  if (isSet(base)) return new Set(base)
+  if (Object.getPrototypeOf(base) === Object.prototype) {
+    return quickCopyObj(base)
+  }
+  return strictCopy(base)
 }
 
 export const ownKeys: (target: object) => PropertyKey[] =


### PR DESCRIPTION
before:
Naive handcrafted reducer x 3,715 ops/sec ±1.24% (90 runs sampled)
Mutative x 5,428 ops/sec ±1.23% (94 runs sampled)
Doura x 1,042 ops/sec ±4.17% (88 runs sampled)

after:
Naive handcrafted reducer x 3,609 ops/sec ±2.02% (87 runs sampled)
Mutative x 5,383 ops/sec ±1.64% (86 runs sampled)
Doura x 2,246 ops/sec ±4.10% (83 runs sampled)